### PR TITLE
define unique_id for all created entities

### DIFF
--- a/custom_components/alert2/binary_sensor.py
+++ b/custom_components/alert2/binary_sensor.py
@@ -13,6 +13,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     aSensor = BinarySensorEntity()
     aSensor._attr_is_on = False
     aSensor._attr_name = 'alert2 ha_startup_done'
+    aSensor._attr_unique_id = aSensor._attr_name
     aSensor._attr_should_poll = False
     aSensor._attr_device_class = None
 


### PR DESCRIPTION
This allows the entities to be edited via the UI.

* https://www.home-assistant.io/faq/unique_id/
* https://developers.home-assistant.io/docs/entity_registry_index/

I tested that it works in Home Assistant. But I have not tested this for long yet and I have not extensively researched if this is the best approach. I don’t have that much experience with developing for Home Assistant.

Sorry for the white space change. I had my editor configured to do that. I thought about figuring out how to disable that but then I thought clearing that white space is technically correct. Maybe you could setup https://pre-commit.com/ to clean white space before you commit?